### PR TITLE
Replace debugging prints with structured logging

### DIFF
--- a/scripts/HMDALoader.py
+++ b/scripts/HMDALoader.py
@@ -18,12 +18,17 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Sequence, Tuple, Union
 
+import logging
+
 import pandas as pd
 import polars as pl
 import pyarrow as pa
 import pyarrow.parquet as pq
 
 import config
+
+
+logger = logging.getLogger(__name__)
 
 
 EngineName = Literal["pandas", "pyarrow", "polars"]
@@ -156,7 +161,7 @@ def load_hmda_file(
         :func:`pyarrow.parquet.read_table`.  The structure should follow the
         [PyArrow filter specification](https://arrow.apache.org/docs/python/parquet.html#filters).
     verbose:
-        If ``True``, the function prints the path of each file before it is
+        If ``True``, the function logs the path of each file before it is
         loaded.
     engine:
         Backend used to materialise the parquet data.  ``"pandas"`` returns a
@@ -199,7 +204,7 @@ def load_hmda_file(
     if engine == "pandas":
         for file_path in files:
             if verbose:
-                print("Adding data from file:", file_path)
+                logger.info("Adding data from file: %s", file_path)
             table = pd.read_parquet(
                 file_path,
                 columns=list(columns) if columns is not None else None,
@@ -212,7 +217,7 @@ def load_hmda_file(
     if engine == "pyarrow":
         for file_path in files:
             if verbose:
-                print("Adding data from file:", file_path)
+                logger.info("Adding data from file: %s", file_path)
             table = pq.read_table(
                 file_path,
                 columns=list(columns) if columns is not None else None,
@@ -225,7 +230,7 @@ def load_hmda_file(
     if engine == "polars":
         for file_path in files:
             if verbose:
-                print("Adding data from file:", file_path)
+                logger.info("Adding data from file: %s", file_path)
             table = pl.scan_parquet(str(file_path), **kwargs)
             tables.append(table)
         return pl.concat(tables)

--- a/scripts/match_hmda_sellers_purchasers_post2018.py
+++ b/scripts/match_hmda_sellers_purchasers_post2018.py
@@ -7,6 +7,8 @@ Last updated on: Sat Feb 11 10:45:24 2023
 """
 
 # Import Packages
+import logging
+
 import pandas as pd
 import numpy as np
 import pyarrow as pa
@@ -14,6 +16,9 @@ import pyarrow.parquet as pq
 import HMDALoader
 import config
 from matching_support_functions import *
+
+
+logger = logging.getLogger(__name__)
 
 #%% Match Functions
 # Post-2018 Match
@@ -42,7 +47,7 @@ def match_hmda_sellers_purchasers_round1(data_folder, save_folder, min_year=2018
     df = []
     for year in range(min_year, max_year+1) :
 
-        print(year)
+        logger.info("Matching HMDA sellers and purchasers for year: %s", year)
 
         # Load Data
         df_a = load_data(data_folder, min_year=year, max_year=year)
@@ -911,7 +916,7 @@ def create_matched_file(data_folder, match_folder, min_year=2018, max_year=2023,
     # Combine Seller and Purchaser Data
     df_seller = []
     for year in range(min_year, max_year+1) :
-        print('Keeping matched sold loans from year:', year)
+        logger.info('Keeping matched sold loans from year: %s', year)
         file = HMDALoader.get_hmda_files(data_folder, min_year=year, max_year=year, extension='parquet')[0]
         df_a = pq.read_table(file, filters=[('action_taken','in',[1])]).to_pandas(date_as_object = False)
         df_a = df_a.merge(cw, left_on = ['HMDAIndex'], right_on = ['HMDAIndex_s'], how = 'inner')
@@ -923,7 +928,7 @@ def create_matched_file(data_folder, match_folder, min_year=2018, max_year=2023,
     # Combine Seller and Purchaser Data
     df_purchaser = []
     for year in range(min_year, max_year+1) :
-        print('Keeping matched purchased loans from year:', year)
+        logger.info('Keeping matched purchased loans from year: %s', year)
         file = HMDALoader.get_hmda_files(data_folder, min_year=year, max_year=year, extension='parquet')[0]
         df_a = pq.read_table(file, filters=[('action_taken','in',[6])]).to_pandas(date_as_object = False)
         df_a = df_a.merge(cw, left_on=['HMDAIndex'], right_on=['HMDAIndex_p'])
@@ -1164,7 +1169,9 @@ def get_lei_match_counts(data_folder, match_folder, match_round, min_year=2018, 
 
 #%% Main Routine
 if __name__ == '__main__' :
-    
+
+    logging.basicConfig(level=logging.INFO)
+
     # Unzip HMDA Data
     DATA_DIR = config.DATA_DIR
     DATA_FOLDER = DATA_DIR / 'clean'

--- a/scripts/match_hmda_sellers_purchasers_pre2018.py
+++ b/scripts/match_hmda_sellers_purchasers_pre2018.py
@@ -8,11 +8,16 @@ Last updated on: Saturday March 22 07:45:00 2025
 
 # Import Packages
 import glob
+import logging
+
 import pandas as pd
 import numpy as np
 import pyarrow.parquet as pq
 import pyarrow as pa
 import config
+
+
+logger = logging.getLogger(__name__)
 
 #%% Local Functions
 # Save Crosswalk
@@ -96,7 +101,11 @@ def numeric_matches(df, match_tolerances, verbose = False, drop_differences = Tr
         
         # Display Progress
         if verbose :
-            print('Matching on', column, 'drops',  start_obs-df.shape[0], 'observations')
+            logger.info(
+                "Matching on %s drops %d observations",
+                column,
+                start_obs - df.shape[0],
+            )
 
         # Drop Difference Columns
         if drop_differences :
@@ -318,7 +327,10 @@ def keep_uniques(df, one_to_one = True, verbose = True) :
 
     # Display
     if verbose :
-        print(df[['count_index_s','count_index_p']].value_counts())
+        logger.info(
+            "Match cardinality counts:\n%s",
+            df[['count_index_s', 'count_index_p']].value_counts(),
+        )
 
     # Keep Purchased Loans w/ Unique Match
     df = df.query('count_index_p == 1')
@@ -405,7 +417,7 @@ def match_hmda_sellers_purchasers_round1(data_folder, save_folder, min_year=2007
     for year in range(min_year, max_year+1) :
 
         # Display Progress
-        print('Matching HMDA sellers and purchasers for year:', year)
+        logger.info('Matching HMDA sellers and purchasers for year: %s', year)
 
         # Load Data
         df_a = load_data(data_folder, min_year=year, max_year=year)
@@ -468,7 +480,7 @@ def match_hmda_sellers_purchasers_round1(data_folder, save_folder, min_year=2007
         df_a = df_a.query('property_type_s==property_type_p')
 
         # Display Progress and Append
-        print('Adding', len(df_a), 'matches from year', year)
+        logger.info('Adding %d matches from year %s', len(df_a), year)
         df.append(df_a)
         del df_a
 
@@ -524,7 +536,7 @@ def match_hmda_sellers_purchasers_round2(data_folder, save_folder, min_year = 20
     for year in range(min_year, max_year+1) :
 
         # Display Progress
-        print('Matching HMDA sellers and purchasers for year:', year)
+        logger.info('Matching HMDA sellers and purchasers for year: %s', year)
 
         # Load Data
         df_a = load_data(data_folder, min_year=year, max_year=year)
@@ -625,6 +637,8 @@ def match_hmda_sellers_purchasers_round2(data_folder, save_folder, min_year = 20
 
 #%% Main Routine
 if __name__ == '__main__' :
+
+    logging.basicConfig(level=logging.INFO)
 
     # Set Folder Paths
     DATA_DIR = config.DATA_DIR

--- a/scripts/matching_support_functions.py
+++ b/scripts/matching_support_functions.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 import os
 from typing import Mapping, Optional, Sequence
 
+import logging
+
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
 import HMDALoader
+
+
+logger = logging.getLogger(__name__)
 
 FilterCondition = tuple[str, str, object]
 
@@ -601,7 +606,11 @@ def numeric_matches(
 
             # Display Progress
             if verbose :
-                print('Matching on', column, 'drops',  start_obs-df.shape[0], 'observations')
+                logger.info(
+                    "Matching on %s drops %d observations",
+                    column,
+                    start_obs - df.shape[0],
+                )
 
             # Drop Difference Columns
             if drop_differences :
@@ -659,7 +668,11 @@ def weak_numeric_matches(
 
             # Display Progress
             if verbose :
-                print('Matching weakly on', column, 'drops',  start_obs-df.shape[0], 'observations')
+                logger.info(
+                    "Matching weakly on %s drops %d observations",
+                    column,
+                    start_obs - df.shape[0],
+                )
 
             # Drop Difference Columns
             if drop_differences :
@@ -718,7 +731,10 @@ def numeric_matches_post_unique(
 
     # Display Progress
     if verbose :
-        print('Matching on', column, 'drops',  start_obs-df.shape[0], 'observations')
+        logger.info(
+            "Numeric post-unique filtering removed %d observations",
+            start_obs - df.shape[0],
+        )
 
     # Return DataFrame
     return df
@@ -783,7 +799,10 @@ def keep_uniques(df: pd.DataFrame, one_to_one: bool = True, verbose: bool = True
 
     # Display
     if verbose :
-        print(df[['count_index_s','count_index_p']].value_counts())
+        logger.info(
+            "Match cardinality counts:\n%s",
+            df[['count_index_s', 'count_index_p']].value_counts(),
+        )
 
     # Keep Purchased Loans w/ Unique Match
     df = df.query('count_index_p == 1')
@@ -850,7 +869,7 @@ def save_crosswalk(
     cw = pd.concat(cw)
 
     # Save Crosswalk
-    print(cw.match_round.value_counts())
+    logger.info("Crosswalk match counts by round:\n%s", cw.match_round.value_counts())
     cw = pa.Table.from_pandas(cw, preserve_index=False)
     suffix = file_suffix or ""
     pq.write_table(cw, f'{save_folder}/hmda_seller_purchaser_matches_round{match_round}{suffix}.parquet')


### PR DESCRIPTION
## Summary
- replace ad-hoc print statements across the matching scripts and loader with module-level loggers
- initialize logging when the pre- and post-2018 matching entrypoints are executed directly so progress messages remain visible
- update verbose messaging and documentation to reflect the new logging-based diagnostics

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68da96625fbc8332b16207e6a3090079