### PR TITLE
Remove verbose toggles from matching scripts

### DIFF
--- a/scripts/HMDALoader.py
+++ b/scripts/HMDALoader.py
@@ -136,7 +136,6 @@ def load_hmda_file(
     max_year: int = 2023,
     columns: Optional[Sequence[str]] = None,
     filters: Optional[ParquetFilters] = None,
-    verbose: bool = False,
     engine: EngineName = "pandas",
     **kwargs: Any,
 ) -> Union[pd.DataFrame, pl.LazyFrame, pl.DataFrame, pa.Table]:
@@ -160,9 +159,6 @@ def load_hmda_file(
         Optional predicate passed through to :func:`pandas.read_parquet` or
         :func:`pyarrow.parquet.read_table`.  The structure should follow the
         [PyArrow filter specification](https://arrow.apache.org/docs/python/parquet.html#filters).
-    verbose:
-        If ``True``, the function logs the path of each file before it is
-        loaded.
     engine:
         Backend used to materialise the parquet data.  ``"pandas"`` returns a
         :class:`pandas.DataFrame`, ``"pyarrow"`` returns a :class:`pyarrow.Table`,
@@ -203,8 +199,7 @@ def load_hmda_file(
 
     if engine == "pandas":
         for file_path in files:
-            if verbose:
-                logger.info("Adding data from file: %s", file_path)
+            logger.debug("Adding data from file: %s", file_path)
             table = pd.read_parquet(
                 file_path,
                 columns=list(columns) if columns is not None else None,
@@ -216,8 +211,7 @@ def load_hmda_file(
 
     if engine == "pyarrow":
         for file_path in files:
-            if verbose:
-                logger.info("Adding data from file: %s", file_path)
+            logger.debug("Adding data from file: %s", file_path)
             table = pq.read_table(
                 file_path,
                 columns=list(columns) if columns is not None else None,
@@ -229,8 +223,7 @@ def load_hmda_file(
 
     if engine == "polars":
         for file_path in files:
-            if verbose:
-                logger.info("Adding data from file: %s", file_path)
+            logger.debug("Adding data from file: %s", file_path)
             table = pl.scan_parquet(str(file_path), **kwargs)
             tables.append(table)
         return pl.concat(tables)

--- a/scripts/match_hmda_sellers_purchasers_post2018.py
+++ b/scripts/match_hmda_sellers_purchasers_post2018.py
@@ -79,11 +79,11 @@ def match_hmda_sellers_purchasers_round1(data_folder, save_folder, min_year=2018
             'income': 1,
             'interest_rate': .0625,
         }
-        df_a = numeric_matches(df_a, match_tolerances, verbose=False)
+        df_a = numeric_matches(df_a, match_tolerances)
 
         # Weak Numeric Matches
         match_tolerances = {'interest_rate': .01}
-        df_a = weak_numeric_matches(df_a, match_tolerances, verbose=True)
+        df_a = weak_numeric_matches(df_a, match_tolerances)
 
         # Check for Matches On Any Fee Variables
         df_a = perform_fee_matches(df_a)
@@ -116,7 +116,7 @@ def match_hmda_sellers_purchasers_round1(data_folder, save_folder, min_year=2018
             'applicant_age_above_62': 0,
             'co_applicant_age_above_62': 0,
         }
-        df_a = numeric_matches(df_a, match_tolerances, verbose=True)
+        df_a = numeric_matches(df_a, match_tolerances)
 
         # Clean Up
         df_a['i_DropObservation'] = (np.abs(df_a['interest_rate_s'] - df_a['interest_rate_p']) >= .005) | pd.isna(df_a['income_s']) | pd.isna(df_a['interest_rate_s']) | pd.isna(df_a['property_value_s'])
@@ -174,11 +174,11 @@ def match_hmda_sellers_purchasers_round2(data_folder, save_folder, min_year=2018
     match_tolerances = {'income': 1,
                         'interest_rate': .0625,
                         }
-    df = numeric_matches(df, match_tolerances, verbose=True)
+    df = numeric_matches(df, match_tolerances)
 
     # Weak Numeric Matches
     match_tolerances = {'interest_rate': .01}
-    df = weak_numeric_matches(df, match_tolerances, verbose=True)
+    df = weak_numeric_matches(df, match_tolerances)
 
     # Check for Matches On Any Fee Variables
     df = perform_fee_matches(df)
@@ -210,7 +210,7 @@ def match_hmda_sellers_purchasers_round2(data_folder, save_folder, min_year=2018
                         'applicant_age_above_62': 0,
                         'co_applicant_age_above_62': 0,
                         }
-    df = numeric_matches(df, match_tolerances, verbose=True)
+    df = numeric_matches(df, match_tolerances)
 
     # Clean Up
     df['i_DropObservation'] = (np.abs(df['interest_rate_s'] - df['interest_rate_p']) >= .005) | pd.isna(df['income_s']) | pd.isna(df['interest_rate_s']) | pd.isna(df['property_value_s'])
@@ -276,7 +276,7 @@ def match_hmda_sellers_purchasers_round3(data_folder, save_folder, min_year=2018
                         'open_end_line_of_credit': 0,
                         'total_units': 0,
                         }
-    df = numeric_matches(df, match_tolerances, verbose=True)
+    df = numeric_matches(df, match_tolerances)
 
     # Age, Sex, Ethnicity, and Race Matches
     df = match_age(df)
@@ -290,7 +290,7 @@ def match_hmda_sellers_purchasers_round3(data_folder, save_folder, min_year=2018
 
     # Weak Numeric Matches
     match_tolerances = {'interest_rate': .01}
-    df = weak_numeric_matches(df, match_tolerances, verbose=True)
+    df = weak_numeric_matches(df, match_tolerances)
 
     # Keep Unique Matches
     df = keep_uniques(df, one_to_one=False)
@@ -301,13 +301,13 @@ def match_hmda_sellers_purchasers_round3(data_folder, save_folder, min_year=2018
                         'loan_term': 12,
                         'property_value': 20000,
                         }
-    df = numeric_matches_post_unique(df, match_tolerances, verbose=True)
+    df = numeric_matches_post_unique(df, match_tolerances)
 
     # Save Crosswalk
     save_crosswalk(df, save_folder, match_round=3, file_suffix=file_suffix)
 
 # Round 4: Match without Loan Purpose Match; Keep Tight Fee/Rate/Income Matches
-def match_hmda_sellers_purchasers_round4(data_folder, save_folder, min_year=2018, max_year=2023, verbose=False, file_suffix=None) :
+def match_hmda_sellers_purchasers_round4(data_folder, save_folder, min_year=2018, max_year=2023, file_suffix=None) :
     """
     Round 4 of seller-purchaser matches for 2018 onward.
 
@@ -321,8 +321,6 @@ def match_hmda_sellers_purchasers_round4(data_folder, save_folder, min_year=2018
         DESCRIPTION. The default is 2018.
     max_year : int, optional
         DESCRIPTION. The default is 2023.
-    verbose : boolean, optional
-        DESCRIPTION. The default is False.
 
     Returns
     -------
@@ -364,7 +362,7 @@ def match_hmda_sellers_purchasers_round4(data_folder, save_folder, min_year=2018
                         'open_end_line_of_credit': 0,
                         'total_units': 0,
                         }
-    df = numeric_matches(df, match_tolerances, verbose=True)
+    df = numeric_matches(df, match_tolerances)
 
     # Allow Non-matching refi types
     df = df.query('loan_purpose_s == loan_purpose_p | loan_purpose_s in [31,32] | loan_purpose_p in [31,32]')
@@ -381,7 +379,7 @@ def match_hmda_sellers_purchasers_round4(data_folder, save_folder, min_year=2018
 
     # Weak Numeric Matches
     match_tolerances = {'interest_rate': .01}
-    df = weak_numeric_matches(df, match_tolerances, verbose=True)
+    df = weak_numeric_matches(df, match_tolerances)
 
     # Keep Unique Matches
     df = keep_uniques(df, one_to_one=False)
@@ -392,13 +390,13 @@ def match_hmda_sellers_purchasers_round4(data_folder, save_folder, min_year=2018
                         'loan_term': 12,
                         'property_value': 20000,
                         }
-    df = numeric_matches_post_unique(df, match_tolerances, verbose=True)
+    df = numeric_matches_post_unique(df, match_tolerances)
 
     # Save Crosswalk
     save_crosswalk(df, save_folder, match_round=4, file_suffix=file_suffix)
     
 # Round 5: Allow for slight loan amount mismatches
-def match_hmda_sellers_purchasers_round5(data_folder, save_folder, min_year=2018, max_year=2023, verbose=False, file_suffix=None) :
+def match_hmda_sellers_purchasers_round5(data_folder, save_folder, min_year=2018, max_year=2023, file_suffix=None) :
     """
     Round 5 of seller-purchaser matches for 2018 onward.
 
@@ -412,8 +410,6 @@ def match_hmda_sellers_purchasers_round5(data_folder, save_folder, min_year=2018
         DESCRIPTION. The default is 2018.
     max_year : TYPE, optional
         DESCRIPTION. The default is 2022.
-    verbose : TYPE, optional
-        DESCRIPTION. The default is False.
 
     Returns
     -------
@@ -460,11 +456,11 @@ def match_hmda_sellers_purchasers_round5(data_folder, save_folder, min_year=2018
         match_tolerances = {'income': 1,
                             'interest_rate': .0625,
                             }
-        df_a = numeric_matches(df_a, match_tolerances, verbose=True)
+        df_a = numeric_matches(df_a, match_tolerances)
 
         # Weak Numeric Matches
         match_tolerances = {'interest_rate': .01}
-        df_a = weak_numeric_matches(df_a, match_tolerances, verbose=True)
+        df_a = weak_numeric_matches(df_a, match_tolerances)
 
         # Check for Matches On Any Fee Variables
         df_a = perform_fee_matches(df_a)
@@ -497,7 +493,7 @@ def match_hmda_sellers_purchasers_round5(data_folder, save_folder, min_year=2018
                             'co_applicant_age_above_62': 0,
                             'loan_amount': 10000,
                             }
-        df_a = numeric_matches(df_a, match_tolerances, verbose=True)
+        df_a = numeric_matches(df_a, match_tolerances)
         
         # Clean Up
         df_a['i_DropObservation'] = (np.abs(df_a['interest_rate_s'] - df_a['interest_rate_p']) >= .005) | pd.isna(df_a['income_s']) | pd.isna(df_a['interest_rate_s']) | pd.isna(df_a['property_value_s'])
@@ -522,7 +518,7 @@ def match_hmda_sellers_purchasers_round5(data_folder, save_folder, min_year=2018
     save_crosswalk(df, save_folder, match_round=5, file_suffix=file_suffix)
 
 # Round 6: Affiliate Matches
-def match_hmda_sellers_purchasers_round6(data_folder, save_folder, min_year=2018, max_year=2023, verbose=False, file_suffix=None) :
+def match_hmda_sellers_purchasers_round6(data_folder, save_folder, min_year=2018, max_year=2023, file_suffix=None) :
     """
     Round 5 of seller-purchaser matches for 2018 onward. Match for affiliates.
 
@@ -536,8 +532,6 @@ def match_hmda_sellers_purchasers_round6(data_folder, save_folder, min_year=2018
         DESCRIPTION. The default is 2018.
     max_year : TYPE, optional
         DESCRIPTION. The default is 2022.
-    verbose : TYPE, optional
-        DESCRIPTION. The default is False.
 
     Returns
     -------
@@ -583,7 +577,7 @@ def match_hmda_sellers_purchasers_round6(data_folder, save_folder, min_year=2018
                         'open_end_line_of_credit': 0,
                         'total_units': 0,
                         }
-    df = numeric_matches(df, match_tolerances, verbose = True)
+    df = numeric_matches(df, match_tolerances)
 
     # Allow Non-matching refi types
     df = df.query('loan_purpose_s == loan_purpose_p or loan_purpose_s in [31,32] or loan_purpose_p in [31,32]')
@@ -616,7 +610,7 @@ def match_hmda_sellers_purchasers_round6(data_folder, save_folder, min_year=2018
 
     # Weak Numeric Matches
     match_tolerances = {'interest_rate': .01}
-    df = weak_numeric_matches(df, match_tolerances, verbose=True)
+    df = weak_numeric_matches(df, match_tolerances)
 
     # Keep Only Affiliate Matches
     df = df.merge(affiliated_leis, on=['lei_s','lei_p'])
@@ -630,13 +624,13 @@ def match_hmda_sellers_purchasers_round6(data_folder, save_folder, min_year=2018
                         'loan_term': 12,
                         'property_value': 20000,
                         }
-    df = numeric_matches_post_unique(df, match_tolerances, verbose=True)
+    df = numeric_matches_post_unique(df, match_tolerances)
 
     # Save Crosswalk
     save_crosswalk(df, save_folder, match_round=6, file_suffix=file_suffix)
 
 # Round 7: Match with Purchaser Type
-def match_hmda_sellers_purchasers_round7(data_folder, save_folder, min_year=2018, max_year=2023, verbose=False, file_suffix=None) :
+def match_hmda_sellers_purchasers_round7(data_folder, save_folder, min_year=2018, max_year=2023, file_suffix=None) :
     """
     Round 7 of seller-purchaser matches for 2018 onward.
 
@@ -650,8 +644,6 @@ def match_hmda_sellers_purchasers_round7(data_folder, save_folder, min_year=2018
         DESCRIPTION. The default is 2018.
     max_year : TYPE, optional
         DESCRIPTION. The default is 2022.
-    verbose : TYPE, optional
-        DESCRIPTION. The default is False.
 
     Returns
     -------
@@ -709,7 +701,7 @@ def match_hmda_sellers_purchasers_round7(data_folder, save_folder, min_year=2018
                         'open_end_line_of_credit': 0,
                         'total_units': 0,
                         }
-    df = numeric_matches(df, match_tolerances, verbose=True)
+    df = numeric_matches(df, match_tolerances)
 
     # Age, Sex, Ethnicity, and Race Matches
     df = match_age(df)
@@ -755,13 +747,13 @@ def match_hmda_sellers_purchasers_round7(data_folder, save_folder, min_year=2018
                         'loan_term': 0,
                         'property_value': 10000,
                         }
-    df = numeric_matches_post_unique(df, match_tolerances, verbose=True)
+    df = numeric_matches_post_unique(df, match_tolerances)
 
     # Save Crosswalk
     save_crosswalk(df, save_folder, match_round=7, file_suffix=file_suffix)
 
 # Round 8: Match without PurchaserType=0 Originations
-def match_hmda_sellers_purchasers_round8(data_folder, save_folder, min_year=2018, max_year=2023, verbose=False, file_suffix=None) :
+def match_hmda_sellers_purchasers_round8(data_folder, save_folder, min_year=2018, max_year=2023, file_suffix=None) :
     """
     Round 8 of seller-purchaser matches for 2018 onward.
 
@@ -775,8 +767,6 @@ def match_hmda_sellers_purchasers_round8(data_folder, save_folder, min_year=2018
         DESCRIPTION. The default is 2018.
     max_year : TYPE, optional
         DESCRIPTION. The default is 2022.
-    verbose : TYPE, optional
-        DESCRIPTION. The default is False.
 
     Returns
     -------
@@ -835,7 +825,7 @@ def match_hmda_sellers_purchasers_round8(data_folder, save_folder, min_year=2018
                         'open_end_line_of_credit': 0,
                         'total_units': 0,
                         }
-    df = numeric_matches(df, match_tolerances, verbose=True)
+    df = numeric_matches(df, match_tolerances)
 
     # Age, Sex, Ethnicity, and Race Matches
     df = match_age(df)
@@ -881,7 +871,7 @@ def match_hmda_sellers_purchasers_round8(data_folder, save_folder, min_year=2018
                         'loan_term': 12,
                         'property_value': 30000,
                         }
-    df = numeric_matches_post_unique(df, match_tolerances, verbose=True)
+    df = numeric_matches_post_unique(df, match_tolerances)
 
     # Save Crosswalk
     save_crosswalk(df, save_folder, match_round=8, file_suffix=file_suffix)

--- a/scripts/match_hmda_sellers_purchasers_pre2018.py
+++ b/scripts/match_hmda_sellers_purchasers_pre2018.py
@@ -66,7 +66,7 @@ def save_crosswalk(df, save_folder, match_round = 1) :
               )
     
 # Numeric Matches
-def numeric_matches(df, match_tolerances, verbose = False, drop_differences = True) :
+def numeric_matches(df, match_tolerances, drop_differences = True) :
     """
     Matches for numeric columns.
 
@@ -76,8 +76,6 @@ def numeric_matches(df, match_tolerances, verbose = False, drop_differences = Tr
         Data.
     match_tolerances : dictionary
         Dictionary of match columns and tolerances.
-    verbose : boolean, optional
-        Whether to display number of dropped observations. The default is False.
     drop_differences : boolean, optional
         Whether to drop the created value differences. The default is True.
 
@@ -100,12 +98,11 @@ def numeric_matches(df, match_tolerances, verbose = False, drop_differences = Tr
         df = df.loc[~(np.abs(df[f'{column}_difference']) > tolerance)]
         
         # Display Progress
-        if verbose :
-            logger.info(
-                "Matching on %s drops %d observations",
-                column,
-                start_obs - df.shape[0],
-            )
+        logger.debug(
+            "Matching on %s drops %d observations",
+            column,
+            start_obs - df.shape[0],
+        )
 
         # Drop Difference Columns
         if drop_differences :
@@ -294,7 +291,7 @@ def match_ethnicity(df) :
     return df
 
 # Keep Uniques
-def keep_uniques(df, one_to_one = True, verbose = True) :
+def keep_uniques(df, one_to_one = True) :
     """
     Keep unique matches or matches where a single origination matches to many
     purchasers where one purchaser has a secondary sale.
@@ -305,8 +302,6 @@ def keep_uniques(df, one_to_one = True, verbose = True) :
         Data before unique matches are enforced.
     one_to_one : Boolean, optional
         Whether to only keep unique seller matches. The default is True.
-    verbose : Boolean, optional
-        Whether to display match counts before dropping. The default is True.
 
     Returns
     -------
@@ -326,11 +321,10 @@ def keep_uniques(df, one_to_one = True, verbose = True) :
     df['count_index_p'] = df.groupby(loan_id_columns_p, dropna = False)['activity_year_p'].transform('count')
 
     # Display
-    if verbose :
-        logger.info(
-            "Match cardinality counts:\n%s",
-            df[['count_index_s', 'count_index_p']].value_counts(),
-        )
+    logger.debug(
+        "Match cardinality counts:\n%s",
+        df[['count_index_s', 'count_index_p']].value_counts(),
+    )
 
     # Keep Purchased Loans w/ Unique Match
     df = df.query('count_index_p == 1')
@@ -460,7 +454,7 @@ def match_hmda_sellers_purchasers_round1(data_folder, save_folder, min_year=2007
         df_a = df_a.query('respondent_id_s!=respondent_id_p | agency_code_s!=agency_code_p')
 
         # Keep Unique Loans
-        df_a = keep_uniques(df_a, one_to_one=True, verbose=True)
+        df_a = keep_uniques(df_a, one_to_one=True)
 
         # Keep Similar Loan Amounts and Incomes
         df_a['SizeDifference'] = df_a.loan_amount_s-df_a.loan_amount_p
@@ -603,7 +597,7 @@ def match_hmda_sellers_purchasers_round2(data_folder, save_folder, min_year = 20
     df = df.query('respondent_id_s!=respondent_id_p | agency_code_s!=agency_code_p')
 
     # Keep Unique Loans
-    df = keep_uniques(df, one_to_one=True, verbose=True)
+    df = keep_uniques(df, one_to_one=True)
     
     # Drop Demographic Mismatches
     df = match_sex(df)

--- a/scripts/matching_support_functions.py
+++ b/scripts/matching_support_functions.py
@@ -567,7 +567,6 @@ def perform_income_matches(df: pd.DataFrame) -> pd.DataFrame :
 def numeric_matches(
     df: pd.DataFrame,
     match_tolerances: Mapping[str, float | int],
-    verbose: bool = False,
     drop_differences: bool = True,
 ) -> pd.DataFrame :
     """Keep only records that agree within provided numeric tolerances.
@@ -578,8 +577,6 @@ def numeric_matches(
         Data.
     match_tolerances : Mapping[str, float | int]
         Dictionary of match columns and tolerances.
-    verbose : bool, optional
-        Whether to display number of dropped observations. The default is False.
     drop_differences : bool, optional
         Whether to drop the created value differences. The default is True.
 
@@ -605,12 +602,11 @@ def numeric_matches(
             df = df.query(f'abs({column}_difference) <= {tolerance} or {column}_difference.isnull()')
 
             # Display Progress
-            if verbose :
-                logger.info(
-                    "Matching on %s drops %d observations",
-                    column,
-                    start_obs - df.shape[0],
-                )
+            logger.debug(
+                "Matching on %s drops %d observations",
+                column,
+                start_obs - df.shape[0],
+            )
 
             # Drop Difference Columns
             if drop_differences :
@@ -623,7 +619,6 @@ def numeric_matches(
 def weak_numeric_matches(
     df: pd.DataFrame,
     match_tolerances: Mapping[str, float | int],
-    verbose: bool = False,
     drop_differences: bool = True,
 ) -> pd.DataFrame :
     """Allow slight numeric disagreement while preserving best matches.
@@ -634,8 +629,6 @@ def weak_numeric_matches(
         Data.
     match_tolerances : Mapping[str, float | int]
         Dictionary of match columns and tolerances.
-    verbose : bool, optional
-        Whether to display number of dropped observations. The default is False.
     drop_differences : bool, optional
         Whether to drop the created value differences. The default is True.
 
@@ -667,12 +660,11 @@ def weak_numeric_matches(
             df = df.loc[~(np.abs(df[f'{column}_difference']) > tolerance) | (df[f'min_{column}_difference_p'] > 0) | pd.isna(df[f'min_{column}_difference_p'])]
 
             # Display Progress
-            if verbose :
-                logger.info(
-                    "Matching weakly on %s drops %d observations",
-                    column,
-                    start_obs - df.shape[0],
-                )
+            logger.debug(
+                "Matching weakly on %s drops %d observations",
+                column,
+                start_obs - df.shape[0],
+            )
 
             # Drop Difference Columns
             if drop_differences :
@@ -684,7 +676,6 @@ def weak_numeric_matches(
 def numeric_matches_post_unique(
     df: pd.DataFrame,
     match_tolerances: Mapping[str, float | int],
-    verbose: bool = False,
     drop_differences: bool = True,
 ) -> pd.DataFrame :
     """Re-apply numeric tolerances after enforcing uniqueness constraints.
@@ -695,8 +686,6 @@ def numeric_matches_post_unique(
         Data.
     match_tolerances : Mapping[str, float | int]
         Dictionary of match columns and tolerances.
-    verbose : bool, optional
-        Whether to display number of dropped observations. The default is False.
     drop_differences : bool, optional
         Whether to drop the created value differences. The default is True.
 
@@ -730,11 +719,10 @@ def numeric_matches_post_unique(
     df = df.drop(columns = ['i_DropObservation','i_DropSale'])
 
     # Display Progress
-    if verbose :
-        logger.info(
-            "Numeric post-unique filtering removed %d observations",
-            start_obs - df.shape[0],
-        )
+    logger.debug(
+        "Numeric post-unique filtering removed %d observations",
+        start_obs - df.shape[0],
+    )
 
     # Return DataFrame
     return df
@@ -775,7 +763,7 @@ def perform_fee_matches(df: pd.DataFrame) -> pd.DataFrame :
     return df
 
 # Keep Uniques
-def keep_uniques(df: pd.DataFrame, one_to_one: bool = True, verbose: bool = True) -> pd.DataFrame :
+def keep_uniques(df: pd.DataFrame, one_to_one: bool = True) -> pd.DataFrame :
     """Restrict matches so each purchaser links to a single sale.
 
     Parameters
@@ -784,8 +772,6 @@ def keep_uniques(df: pd.DataFrame, one_to_one: bool = True, verbose: bool = True
         Data before unique matches are enforced.
     one_to_one : bool, optional
         Whether to only keep unique seller matches. The default is True.
-    verbose : bool, optional
-        Whether to display match counts before dropping. The default is True.
 
     Returns
     -------
@@ -798,11 +784,10 @@ def keep_uniques(df: pd.DataFrame, one_to_one: bool = True, verbose: bool = True
     df['count_index_p'] = df.groupby(['HMDAIndex_p'])['HMDAIndex_p'].transform('count')
 
     # Display
-    if verbose :
-        logger.info(
-            "Match cardinality counts:\n%s",
-            df[['count_index_s', 'count_index_p']].value_counts(),
-        )
+    logger.debug(
+        "Match cardinality counts:\n%s",
+        df[['count_index_s', 'count_index_p']].value_counts(),
+    )
 
     # Keep Purchased Loans w/ Unique Match
     df = df.query('count_index_p == 1')


### PR DESCRIPTION
## Summary
- drop the `verbose` keyword arguments from the loader and matching helpers
- rely on debug-level logging instead of per-call verbosity flags and update docstrings accordingly
- adjust all matching workflows to call the updated helpers without the extra argument

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68dafc3fc0948332a8fb8d2197c016bc